### PR TITLE
corrected Py_BuildValue format string

### DIFF
--- a/src/callback.c
+++ b/src/callback.c
@@ -563,12 +563,12 @@ eval_h(Index n, Number * x, Bool new_x, Number obj_factor,
 
 		if (user_data != NULL)
 			arglist =
-			    Py_BuildValue("(OOOO)", arrayx, lagrangex,
+			    Py_BuildValue("(OOOOO)", arrayx, lagrangex,
 					  objfactor, Py_False,
 					  (PyObject *) user_data);
 		else
 			arglist =
-			    Py_BuildValue("(OOOOO)", arrayx, lagrangex,
+			    Py_BuildValue("(OOOO)", arrayx, lagrangex,
 					  objfactor, Py_False);
 		PyArrayObject *result = (PyArrayObject *)
 		    PyObject_CallObject(myowndata->eval_h_python,


### PR DESCRIPTION
I changed the format string in two calls to Py_BuildValue within eval_h; in one instance a length-five tuple was built from four arguments, which led to segfaults at strange times.
