### PR TITLE
automatically adjust IPOPT_LIB for 64-bit case

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,14 @@ IPOPT_DIR='/home/ebogart/Ipopt-3.10.1/build-systemblas/'
 # ========= Edit The Line Above ==============
 
 # ========= Don't touch things below this ====
+import os
 from distutils.core import setup
 from distutils.extension import Extension
 
-IPOPT_LIB=IPOPT_DIR+"lib"
+if os.path.isdir(IPOPT_DIR + 'lib'): 
+    IPOPT_LIB=IPOPT_DIR+"lib"
+else:
+    IPOPT_LIB=IPOPT_DIR+"lib64"
 IPOPT_INC=IPOPT_DIR+"include/coin/"
 
 #find the numpy headers automatically


### PR DESCRIPTION
In 64-bit system  IPOPT_LIB should be IPOPT_DIR + 'lib64'
