### PR TITLE
Added a dimensionality check for x0 to avoid confusing errors.

### DIFF
--- a/src/callback.c
+++ b/src/callback.c
@@ -41,10 +41,9 @@ void logger(const char *fmt, ...)
 	if (user_log_level == VERBOSE) {
 		va_list ap;
 		va_start(ap, fmt);
-		vprintf(fmt, ap);
+		PySys_WriteStdout(fmt, ap);
 		va_end(ap);
-		printf("\n");
-		fflush(stdout);
+		PySys_WriteStdout("\n");
 	}
 }
 

--- a/src/pyipoptcoremodule.c
+++ b/src/pyipoptcoremodule.c
@@ -590,6 +590,17 @@ PyObject *solve(PyObject * self, PyObject * args)
 		SAFE_FREE(newx0);
 		return retval;
 	}
+	if (x0->nd != 1){ //If x0 is not 1-dimensional then solve will fail and cause a segmentation fault.
+		logger("[ERROR] x0 must be a 1-dimensional array");
+		Py_XDECREF(x);
+		Py_XDECREF(mL);
+		Py_XDECREF(mU);
+		Py_XDECREF(lambda);
+		PyErr_SetString(PyExc_TypeError,
+				"x0 passed to solve is not 1-dimensional.");
+		return NULL;
+	}
+
 	if (myuserdata != NULL) {
 		bigfield->userdata = myuserdata;
 		/*

--- a/src/pyipoptcoremodule.c
+++ b/src/pyipoptcoremodule.c
@@ -275,7 +275,7 @@ static PyObject *set_loglevel(PyObject * obj, PyObject * args)
 {
 	int l;
 	if (!PyArg_ParseTuple(args, "i", &l)) {
-		printf("l is %d \n", l);
+		PySys_WriteStdout("l is %d \n", l);
 		return NULL;
 	}
 	if (l < 0 || l > 2) {


### PR DESCRIPTION
If the user passes any array that is not one dimensional to nlp.solve then errors will occur in the solver and ultimately `SAFE_FREE(newx0)` at https://github.com/xuy/pyipopt/blob/ab61f901f91d08343eda66545bd6cfb4f68f63b1/src/pyipoptcoremodule.c#L685 will result in a segmentation fault. 

In my case I was using a numpy.matrix object which is always 2-dimensional.

This pull request adds a dimensionality check to the solve function and raises an error of x0 is not 1-dimensional.