### PR TITLE
print to python sys.stdout instead of stdout.

### DIFF
--- a/src/callback.c
+++ b/src/callback.c
@@ -41,10 +41,9 @@ void logger(const char *fmt, ...)
 	if (user_log_level == VERBOSE) {
 		va_list ap;
 		va_start(ap, fmt);
-		vprintf(fmt, ap);
+		PySys_WriteStdout(fmt, ap);
 		va_end(ap);
-		printf("\n");
-		fflush(stdout);
+		PySys_WriteStdout("\n");
 	}
 }
 

--- a/src/pyipoptcoremodule.c
+++ b/src/pyipoptcoremodule.c
@@ -275,7 +275,7 @@ static PyObject *set_loglevel(PyObject * obj, PyObject * args)
 {
 	int l;
 	if (!PyArg_ParseTuple(args, "i", &l)) {
-		printf("l is %d \n", l);
+		PySys_WriteStdout("l is %d \n", l);
 		return NULL;
 	}
 	if (l < 0 || l > 2) {


### PR DESCRIPTION
This pull request will allow pyipopts output to be viewed in the redirected python console. Currently it outputs to stdout which can only be seen when running from the terminal.