### PR TITLE
pkg-config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,40 @@ PyIpopt depends on the following packages:
 
 First, get the latest source code using:
 
-  $ git clone http://github.com/xuy/pyipopt.git
+	$ git clone http://github.com/xuy/pyipopt.git
 
-In your PyIpopt folder, edit setup.py to reflect the configuration of your system, then do
+Check whether a file `ipopt.pc` was distributed with your Ipopt installation.
+If this is the case and `ipopt.pc` is in the search path of `pkg-config`
+(on unix systems:
+`/usr/lib/pkgconfig`, `/usr/share/pkgconfig`, `/usr/local/lib/pkgconfig`,
+`/usr/local/share/pkgconfig`), nothing has to be modified.
+
+In this case run
 
 	$ python setup.py build
 	$ sudo python setup.py install
+	
+If `pkg-config` is not available for your system, you will need to
+edit the function `fallback_compiler_flags` in `setup.py`.
+	
+If you have an `ipopt.pc` which is not in the `pkg-config` search path,
+specify the path via the `PKG_CONFIG_PATH` environment variable (see below).
+If you cannot find an `ipopt.pc` in your `ipopt` installation, there is an
+example pc file in the directory `pkgconfig`.
+Copy it to a location (best of all directly in a subfolder named
+`pkgconfig` of your Ipopt installation) and edit it to reflect the
+library and include paths of the dependencies.
+
+Then do
+
+```sh
+$ PKG_CONFIG_PATH=<dir containing ipopt.pc> python setup.py build
+$ sudo python setup.py install
+```
 
 ### Test
 
-  $ python hs071.py
+	$ python hs071.py
 
 You should be able to see the result of solving the toy problem.
 
@@ -36,16 +60,18 @@ Usage
 -----
 You can use PyIpopt like this:
 
-	import pyipopt
-	# define your call back functions
-	nlp = pyipopt.create(...)
-	nlp.solve(...)
-	nlp.close()
+```python
+import pyipopt
+# define your call back functions
+nlp = pyipopt.create(...)
+nlp.solve(...)
+nlp.close()
+```
 
-You can also check out hs071.py to see how to use PyIpopt.
+You can also check out `examples/hs071.py` to see how to use PyIpopt.
 
 PyIpopt as a module comes with docstring. You can poke around 
-it by using Python's $help()$ command.
+it by using Python's `help()` command.
 
 Testing
 -------
@@ -54,7 +80,7 @@ I have included an example
 
 To see if you have PyIpopt ready, use the following command under the pyipopt's directory. 
 
-		python hs071.py
+	$ python hs071.py
 	
 The file "hs071.py" contains a toy optimization problem. If everything is OK, pyipopt will invoke Ipopt to solve it for you. This python file is self-documented and can be used as a template for writing your own optimization problems. 
 
@@ -79,8 +105,8 @@ Troubleshooting
 
 PyIpopt links to Ipopt's C library. If that library is not available PyIpopt will fail
 during module initialization. To check the availability of this library, you can go to
-	$IPOPT_DIR/Ipopt/examples/hs071_c/
-and issue $make to ensure you can compile and run the toy example supplied by Ipopt. 
+`$IPOPT_DIR/Ipopt/examples/hs071_c/`
+and issue `make` to ensure you can compile and run the toy example supplied by Ipopt. 
 
 ### Miscellaneous problems
 
@@ -140,5 +166,3 @@ Contact
 Eric Xu <xu.mathena@gmail.com>
 
 Software Engineer @ Google
-
-

--- a/pkgconfig/ipopt.pc
+++ b/pkgconfig/ipopt.pc
@@ -1,0 +1,20 @@
+# When I installed Ipopt from source, I used the
+# --prefix=/usr/local
+# option, so this is where I want pyipopt to look for my ipopt installation.
+# I only installed from source because the ipopt packaging
+# for my linux distribution was buggy,
+# so by the time you read this the bugs have probably been fixed
+# and you will want to specify a different directory here.
+
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include/coin
+
+Name: IPOPT
+Version:
+Description: Interior Point Optimizer
+URL: https://projects.coin-or.org/Ipopt
+Libs: -L${libdir} -lipopt -lcoinblas -lcoinmumps -lcoinmetis -lcoinlapack -lm -ldl
+Cflags: -I${includedir}
+Requires: 

--- a/setup.py
+++ b/setup.py
@@ -1,72 +1,120 @@
-# Originally contributed by Lorne McIntosh.
-# Modified by Eric Xu
-# Further modification by random internet people.
+"""
+Originally contributed by Lorne McIntosh.
+Modified by Eric Xu
+Further modification by random internet people.
 
-# You will probably have to edit this file in unpredictable ways
-# if you want pyipopt to work for you, sorry.
-
-# When I installed Ipopt from source, I used the
-# --prefix=/usr/local
-# option, so this is where I want pyipopt to look for my ipopt installation.
-# I only installed from source because the ipopt packaging
-# for my linux distribution was buggy,
-# so by the time you read this the bugs have probably been fixed
-# and you will want to specify a different directory here.
-IPOPT_DIR = '/usr/local/'
+You will probably have to edit this file in unpredictable ways
+if you want pyipopt to work for you, sorry.
+"""
 
 import os
+import subprocess
+import warnings
 from distutils.core import setup
 from distutils.extension import Extension
 
 # NumPy is much easier to install than pyipopt,
 # and is a pyipopt dependency, so require it here.
 # We need it to tell us where the numpy header files are.
-import numpy
-numpy_include = numpy.get_include()
+from numpy import get_include as numpy_get_include
 
-# I personally do not need support for lib64 but I'm keeping it in the code.
-def get_ipopt_lib():
+
+def get_compiler_flags():
+    """
+    Tries to find all needed compiler flags needed to compile the extension
+    """
+    numpy_include = numpy_get_include()
+    try:
+        return pkgconfig("ipopt", include_dirs=[numpy_include])
+    except (RuntimeError, FileNotFoundError) as e:
+        warnings.warn("pkg-config not installed or malformed pc file.\n"
+                      "Trying with fallback values. This will probably not work.\n"
+                      "Message from pkg-config:\n{}".format(e.args[0]))
+        return fallback_compiler_flags()
+
+
+def pkgconfig(*packages, **kwargs):
+    """
+    Calls pkg-config returning a dict containing all arguments
+    for Extension() needed to compile the extension
+    """
+    flag_map = {b'-I': 'include_dirs',
+                b'-L': 'library_dirs',
+                b'-l': 'libraries',
+                b'-D': 'define_macros'}
+    res = subprocess.run(
+        ("pkg-config", "--libs", "--cflags")
+        + packages, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    if res.stderr:
+        raise RuntimeError(res.stderr.decode())
+    for token in res.stdout.split():
+        kwargs.setdefault(flag_map.get(token[:2]), []).append(
+            token[2:].decode())
+    define_macros = kwargs.get('define_macros')
+    if define_macros:
+        kwargs['define_macros'] = [tuple(d.split()) for d in define_macros]
+    undefined_flags = kwargs.pop(None, None)
+    if undefined_flags:
+        warnings.warn(
+            "Ignoring flags {} from pkg-config".format(", ".join(undefined_flags)))
+    return kwargs
+
+
+def fallback_compiler_flags():
+    """
+    This gets called if pkg-config is not installed on your system.
+    Comments:
+    When I installed Ipopt from source, I used the
+    --prefix=/usr/local
+    option, so this is where I want pyipopt to look for my ipopt installation.
+    I only installed from source because the ipopt packaging
+    for my linux distribution was buggy,
+    so by the time you read this the bugs have probably been fixed
+    and you will want to specify a different directory here.
+    The extra_link_args is commented out here;
+    that line was causing my pyipopt install to not work.
+    Also I am using coinmumps instead of coinhsl.
+    """
+    IPOPT_DIR = '/usr/local/'
+    IPOPT_INC = os.path.join(IPOPT_DIR, 'include/coin/')
+    return {
+        "libraries": [
+            'ipopt', 'coinblas',
+            # 'coinhsl',
+            'coinmumps',
+            'coinmetis',
+            'coinlapack', 'dl', 'm',
+        ],
+        "include_dirs": [numpy_get_include(), IPOPT_INC],
+        "library_dirs": [get_ipopt_lib(IPOPT_DIR)]
+        # ,"extra_link_args": ['-Wl,--rpath','-Wl,'+ IPOPT_LIB]
+    }
+
+
+def get_ipopt_lib(IPOPT_DIR):
     for lib_suffix in ('lib', 'lib64'):
         d = os.path.join(IPOPT_DIR, lib_suffix)
         if os.path.isdir(d):
             return d
+    raise FileNotFoundError('failed to find ipopt lib')
 
-IPOPT_LIB = get_ipopt_lib()
-if IPOPT_LIB is None:
-    raise Exception('failed to find ipopt lib')
 
-IPOPT_INC = os.path.join(IPOPT_DIR, 'include/coin/')
-
-FILES = ['src/callback.c', 'src/pyipoptcoremodule.c']
-
-# The extra_link_args is commented out here;
-# that line was causing my pyipopt install to not work.
-# Also I am using coinmumps instead of coinhsl.
 pyipopt_extension = Extension(
-        'pyipoptcore',
-        FILES,
-        #extra_link_args=['-Wl,--rpath','-Wl,'+ IPOPT_LIB],
-        library_dirs=[IPOPT_LIB],
-        libraries=[
-            'ipopt', 'coinblas',
-            #'coinhsl',
-            'coinmumps',
-            'coinmetis',
-            'coinlapack','dl','m',
-            ],
-        include_dirs=[numpy_include, IPOPT_INC],
-        )
+    'pyipoptcore',
+    sources=['src/callback.c', 'src/pyipoptcoremodule.c'],
+    **get_compiler_flags()
+)
 
 setup(
-        name="pyipopt",
-        version="0.8",
-        description="An IPOPT connector for Python",
-        author="Eric Xu",
-        author_email="xu.mathena@gmail.com",
-        url="https://github.com/xuy/pyipopt",
-        packages=['pyipopt'],
-        package_dir={'pyipopt' : 'pyipoptpackage'},
-        ext_package='pyipopt',
-        ext_modules=[pyipopt_extension],
-        )
-
+    name="pyipopt",
+    version="0.8",
+    description="An IPOPT connector for Python",
+    author="Eric Xu",
+    author_email="xu.mathena@gmail.com",
+    url="https://github.com/xuy/pyipopt",
+    packages=['pyipopt'],
+    package_dir={'pyipopt': 'pyipoptpackage'},
+    ext_package='pyipopt',
+    ext_modules=[pyipopt_extension],
+)


### PR DESCRIPTION
This adds support for pkg-config, simplifying the dependency path discovery for all systems having
pkg-config installed.
A smple .pc file is provided in the pkgconfig directory.
If pkg-config is not available, fallback compiler flags are used (the previous ones)